### PR TITLE
Implement basic workflow execution

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -12,3 +12,16 @@ uvicorn app.main:app --reload
 ```
 
 The API exposes a basic `/health` endpoint and a `/workflows` endpoint for creating workflows.
+
+Additional endpoints allow listing, retrieving and executing workflows:
+
+```
+GET  /workflows                # list workflows
+GET  /workflows/{id}           # retrieve a workflow
+POST /workflows/{id}/execute   # run a workflow and return logs
+```
+
+Two simple node types are implemented:
+
+- `print` – logs a message
+- `add` – adds two numbers and logs the result

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,13 +1,22 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
-from typing import List
+from typing import List, Dict, Any
 
 app = FastAPI(title="NEXUS AI Backend")
+
+class Node(BaseModel):
+    id: str
+    type: str
+    params: Dict[str, Any] = {}
+
 
 class Workflow(BaseModel):
     id: str
     name: str
-    nodes: List[dict]
+    nodes: List[Node]
+
+
+WORKFLOWS: Dict[str, Workflow] = {}
 
 @app.get("/health")
 def health_check():
@@ -15,4 +24,46 @@ def health_check():
 
 @app.post("/workflows", response_model=Workflow)
 def create_workflow(workflow: Workflow):
+    WORKFLOWS[workflow.id] = workflow
     return workflow
+
+
+@app.get("/workflows", response_model=List[Workflow])
+def list_workflows():
+    return list(WORKFLOWS.values())
+
+
+@app.get("/workflows/{workflow_id}", response_model=Workflow)
+def get_workflow(workflow_id: str):
+    if workflow_id not in WORKFLOWS:
+        raise HTTPException(status_code=404, detail="Workflow not found")
+    return WORKFLOWS[workflow_id]
+
+
+def execute_node(node: Node, logs: List[str], context: Dict[str, Any]):
+    if node.type == "print":
+        message = node.params.get("message", "")
+        logs.append(message)
+    elif node.type == "add":
+        a = node.params.get("a", 0)
+        b = node.params.get("b", 0)
+        result = a + b
+        logs.append(f"{a} + {b} = {result}")
+        context[node.id] = result
+    else:
+        logs.append(f"Unknown node type: {node.type}")
+
+
+@app.post("/workflows/{workflow_id}/execute")
+def execute_workflow(workflow_id: str):
+    if workflow_id not in WORKFLOWS:
+        raise HTTPException(status_code=404, detail="Workflow not found")
+
+    workflow = WORKFLOWS[workflow_id]
+    logs: List[str] = []
+    context: Dict[str, Any] = {}
+
+    for node in workflow.nodes:
+        execute_node(node, logs, context)
+
+    return {"logs": logs}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React</title>
+    <title>NEXUS AI</title>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,42 +1,14 @@
-#root {
-  max-width: 1280px;
+.container {
+  max-width: 600px;
   margin: 0 auto;
   padding: 2rem;
   text-align: center;
 }
 
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
-}
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
-}
-.logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
-}
-
-@keyframes logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
-}
-
-@media (prefers-reduced-motion: no-preference) {
-  a:nth-of-type(2) .logo {
-    animation: logo-spin infinite 20s linear;
-  }
-}
-
-.card {
-  padding: 2em;
-}
-
-.read-the-docs {
-  color: #888;
+pre {
+  background: #1a1a1a;
+  color: #ffffff;
+  padding: 1rem;
+  text-align: left;
+  overflow: auto;
 }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,34 +1,39 @@
 import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
 import './App.css'
 
 function App() {
-  const [count, setCount] = useState(0)
+  const [logs, setLogs] = useState([])
+
+  const runWorkflow = async () => {
+    const workflow = {
+      id: 'demo',
+      name: 'Demo Workflow',
+      nodes: [
+        { id: '1', type: 'print', params: { message: 'Hello from NEXUS' } },
+        { id: '2', type: 'add', params: { a: 2, b: 3 } }
+      ]
+    }
+
+    await fetch('http://localhost:8000/workflows', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(workflow)
+    })
+
+    const res = await fetch(`http://localhost:8000/workflows/${workflow.id}/execute`, {
+      method: 'POST'
+    })
+
+    const data = await res.json()
+    setLogs(data.logs || [])
+  }
 
   return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.jsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
+    <div className="container">
+      <h1>NEXUS AI</h1>
+      <button onClick={runWorkflow}>Run Demo Workflow</button>
+      <pre>{logs.join('\n')}</pre>
+    </div>
   )
 }
 


### PR DESCRIPTION
## Summary
- flesh out FastAPI server with in-memory workflows
- describe API endpoints in backend docs
- add a demo React page to run an example workflow
- clean up default frontend styles

## Testing
- `npm run lint`
- `npm run build`
- `python3 -m py_compile backend/app/main.py`


------
https://chatgpt.com/codex/tasks/task_e_686bd2190f1083249ab738c4bb6b7694