### PR TITLE
Fix failing tests

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -131,12 +131,6 @@ async def execute_node(node: Node, logs: List[str], context: Dict[str, Any]):
             await log(f"{agent_name} -> {response}", logs)
     else:
         await log(f"Unknown node type: {node.type}", logs)
-def execute_node(node: Node, logs: List[str], context: Dict[str, Any]):
-    node_cls = NODE_REGISTRY.get(node.type)
-    if not node_cls:
-        logs.append(f"Unknown node type: {node.type}")
-        return
-    node_cls.execute(node.dict(), logs, context)
 
 
 

--- a/backend/tests/test_nodes.py
+++ b/backend/tests/test_nodes.py
@@ -1,6 +1,9 @@
 import json
+import sys
+from pathlib import Path
 from fastapi.testclient import TestClient
 
+sys.path.append(str(Path(__file__).resolve().parents[1]))
 from app.main import app, WORKFLOWS
 from app.nodes import NODE_REGISTRY
 


### PR DESCRIPTION
## Summary
- fix import path in test_nodes
- remove duplicate execute_node function to prevent async call errors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bd99bb6588324b09ee0625d42564d