### PR TITLE
Add start script for backend and frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,15 @@ This repository contains the initial scaffolding for **NEXUS AI**, a visual work
 
 ## Getting Started
 
+You can quickly update the repository and launch both the backend and
+frontend servers with the provided `start.sh` script:
+
+```bash
+./start.sh
+```
+
+To run the servers manually follow the steps below.
+
 ### Frontend
 
 ```bash

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -e
+
+# Update repository
+if git rev-parse --is-inside-work-tree > /dev/null 2>&1; then
+  echo "Updating repository..."
+  git pull --ff-only
+fi
+
+# Start backend
+pushd backend > /dev/null
+python3 -m venv .venv >/dev/null 2>&1 || true
+source .venv/bin/activate
+pip install -r requirements.txt
+uvicorn app.main:app --reload &
+BACKEND_PID=$!
+popd > /dev/null
+
+# Start frontend
+pushd frontend > /dev/null
+npm install
+npm run dev &
+FRONTEND_PID=$!
+popd > /dev/null
+
+echo "Backend running with PID $BACKEND_PID"
+echo "Frontend running with PID $FRONTEND_PID"
+
+trap "echo Stopping...; kill $BACKEND_PID $FRONTEND_PID" INT TERM
+
+wait $BACKEND_PID $FRONTEND_PID


### PR DESCRIPTION
## Summary
- create `start.sh` script to update repo and run both servers
- document usage of `start.sh` in README

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bddae4e18832482f2099c0047c88a