### PR TITLE
Implement condition/loop nodes and agent API

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -24,10 +24,17 @@ POST /workflows/{id}/save      # save workflow to disk
 POST /workflows/{id}/load      # load workflow from disk
 ```
 
-Two simple node types are implemented:
+Several node types are implemented:
 
 - `print` – logs a message
 - `add` – adds two numbers and logs the result
+- `condition` – evaluates a boolean expression using workflow context
+- `loop` – logs a message for a configurable number of iterations
 
-These nodes are registered using a simple node factory, allowing new node types
-to be added by registering additional classes in `app/nodes.py`.
+Nodes are registered using a simple node factory, allowing new types to be added
+by registering additional classes in `app/nodes.py`.
+
+New agent helper endpoints are also available:
+
+- `GET  /agents` – list available agents
+- `POST /agents/{name}/test` – run an agent with a prompt for quick testing

--- a/backend/app/nodes.py
+++ b/backend/app/nodes.py
@@ -74,3 +74,54 @@ class AddNode(NodeBase):
         if not isinstance(params.get("b"), (int, float)):
             errors.append("'b' must be a number")
         return errors
+
+
+@register_node
+class ConditionNode(NodeBase):
+    type = "condition"
+
+    @classmethod
+    def execute(
+        cls,
+        node: Dict[str, Any],
+        logs: List[str],
+        context: Dict[str, Any],
+    ):
+        params = node.get("params", {})
+        expr = params.get("expression", "")
+        try:
+            result = bool(eval(expr, {}, context))
+        except Exception as e:
+            result = False
+            logs.append(f"Condition error: {e}")
+        logs.append(f"{expr} -> {result}")
+        context[node.get("id", "cond")] = result
+
+    @classmethod
+    def validate(cls, params: Dict[str, Any]) -> List[str]:
+        if "expression" not in params:
+            return ["missing 'expression'"]
+        return []
+
+
+@register_node
+class LoopNode(NodeBase):
+    type = "loop"
+
+    @classmethod
+    def execute(
+        cls,
+        node: Dict[str, Any],
+        logs: List[str],
+        context: Dict[str, Any],
+    ):
+        params = node.get("params", {})
+        count = int(params.get("count", 1))
+        for i in range(count):
+            logs.append(f"loop {i + 1}/{count}")
+
+    @classmethod
+    def validate(cls, params: Dict[str, Any]) -> List[str]:
+        if not isinstance(params.get("count"), int) or params.get("count") < 1:
+            return ["'count' must be a positive integer"]
+        return []

--- a/backend/tests/test_agents_api.py
+++ b/backend/tests/test_agents_api.py
@@ -1,0 +1,19 @@
+import sys
+from pathlib import Path
+from fastapi.testclient import TestClient
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app.main import app
+
+client = TestClient(app)
+
+def test_list_agents():
+    res = client.get("/agents")
+    assert res.status_code == 200
+    assert "echo" in res.json()
+
+def test_test_agent():
+    res = client.post("/agents/echo/test", json={"prompt": "hi"})
+    assert res.status_code == 200
+    assert res.json()["response"] == "ECHO: hi"

--- a/backend/tests/test_nodes.py
+++ b/backend/tests/test_nodes.py
@@ -14,6 +14,8 @@ client = TestClient(app)
 def test_node_registry():
     assert 'print' in NODE_REGISTRY
     assert 'add' in NODE_REGISTRY
+    assert 'condition' in NODE_REGISTRY
+    assert 'loop' in NODE_REGISTRY
 
 
 def test_workflow_validation_and_execution():
@@ -22,7 +24,9 @@ def test_workflow_validation_and_execution():
         "name": "Demo",
         "nodes": [
             {"id": "1", "type": "print", "params": {"message": "hi"}},
-            {"id": "2", "type": "add", "params": {"a": 1, "b": 2}}
+            {"id": "2", "type": "add", "params": {"a": 1, "b": 2}},
+            {"id": "3", "type": "condition", "params": {"expression": "1 < 2"}},
+            {"id": "4", "type": "loop", "params": {"count": 2}}
         ]
     }
     res = client.post("/workflows", json=workflow)
@@ -35,7 +39,10 @@ def test_workflow_validation_and_execution():
     # execute
     res = client.post("/workflows/wf1/execute")
     data = res.json()
-    assert "1 + 2 = 3" in "\n".join(data["logs"])
+    log_text = "\n".join(data["logs"])
+    assert "1 + 2 = 3" in log_text
+    assert "1 < 2 -> True" in log_text
+    assert "loop 1/2" in log_text
 
     # save
     res = client.post("/workflows/wf1/save")


### PR DESCRIPTION
## Summary
- implement `condition` and `loop` node types
- add agent list and test endpoints
- extend execution engine to handle new nodes
- expand backend README
- test new nodes and agent endpoints

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686c8adef8008324b82b20691fcbe95c