### PR TITLE
Implement workflow update and delete endpoints

### DIFF
--- a/backend/tests/test_workflow_crud.py
+++ b/backend/tests/test_workflow_crud.py
@@ -1,0 +1,29 @@
+import sys
+from pathlib import Path
+from fastapi.testclient import TestClient
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app.main import app, WORKFLOWS
+
+client = TestClient(app)
+
+
+def test_update_and_delete_workflow():
+    workflow = {
+        "id": "crud1",
+        "name": "CRUD",
+        "nodes": [{"id": "1", "type": "print", "params": {"message": "hello"}}],
+    }
+    res = client.post("/workflows", json=workflow)
+    assert res.status_code == 200
+
+    updated = workflow.copy()
+    updated["name"] = "Updated"
+    res = client.put(f"/workflows/{workflow['id']}", json=updated)
+    assert res.status_code == 200
+    assert res.json()["name"] == "Updated"
+
+    res = client.delete(f"/workflows/{workflow['id']}")
+    assert res.status_code == 200
+    assert workflow["id"] not in WORKFLOWS


### PR DESCRIPTION
## Summary
- implement workflow `PUT` and `DELETE` endpoints in FastAPI backend
- remove saved workflow file on delete
- add CRUD tests for workflows

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c9ea42dac8324b3aaf72d3ce8ea77