### PR TITLE
Implement multiply node

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -250,6 +250,12 @@ async def execute_node(node: Node, logs: List[str], context: Dict[str, Any]):
         result = a + b
         await log(f"{a} + {b} = {result}", logs)
         context[node.id] = result
+    elif node.type == "multiply":
+        a = node.params.get("a", 0)
+        b = node.params.get("b", 0)
+        result = a * b
+        await log(f"{a} * {b} = {result}", logs)
+        context[node.id] = result
     elif node.type == "condition":
         expr = node.params.get("expression", "")
         try:

--- a/backend/app/nodes.py
+++ b/backend/app/nodes.py
@@ -78,6 +78,34 @@ class AddNode(NodeBase):
 
 
 @register_node
+class MultiplyNode(NodeBase):
+    type = "multiply"
+
+    @classmethod
+    def execute(
+        cls,
+        node: Dict[str, Any],
+        logs: List[str],
+        context: Dict[str, Any],
+    ):
+        params = node.get("params", {})
+        a = params.get("a", 0)
+        b = params.get("b", 0)
+        result = a * b
+        logs.append(f"{a} * {b} = {result}")
+        context[node.get("id", "result")] = result
+
+    @classmethod
+    def validate(cls, params: Dict[str, Any]) -> List[str]:
+        errors = []
+        if not isinstance(params.get("a"), (int, float)):
+            errors.append("'a' must be a number")
+        if not isinstance(params.get("b"), (int, float)):
+            errors.append("'b' must be a number")
+        return errors
+
+
+@register_node
 class ConditionNode(NodeBase):
     type = "condition"
 

--- a/backend/tests/test_nodes.py
+++ b/backend/tests/test_nodes.py
@@ -16,6 +16,7 @@ def test_node_registry():
     assert 'add' in NODE_REGISTRY
     assert 'condition' in NODE_REGISTRY
     assert 'loop' in NODE_REGISTRY
+    assert 'multiply' in NODE_REGISTRY
 
 
 def test_workflow_validation_and_execution():
@@ -25,9 +26,10 @@ def test_workflow_validation_and_execution():
         "nodes": [
             {"id": "1", "type": "print", "params": {"message": "hi"}},
             {"id": "2", "type": "add", "params": {"a": 1, "b": 2}},
-            {"id": "3", "type": "condition", "params": {"expression": "1 < 2"}},
-            {"id": "4", "type": "loop", "params": {"count": 2}},
-            {"id": "5", "type": "delay", "params": {"ms": 10}}
+            {"id": "3", "type": "multiply", "params": {"a": 3, "b": 4}},
+            {"id": "4", "type": "condition", "params": {"expression": "1 < 2"}},
+            {"id": "5", "type": "loop", "params": {"count": 2}},
+            {"id": "6", "type": "delay", "params": {"ms": 10}}
         ]
     }
     res = client.post("/workflows", json=workflow)
@@ -42,6 +44,7 @@ def test_workflow_validation_and_execution():
     data = res.json()
     log_text = "\n".join(data["logs"])
     assert "1 + 2 = 3" in log_text
+    assert "3 * 4 = 12" in log_text
     assert "1 < 2 -> True" in log_text
     assert "loop 1/2" in log_text
 


### PR DESCRIPTION
## Summary
- support MultiplyNode for workflows
- test MultiplyNode registration and execution

## Testing
- `cd backend && pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ca42eab348324be064f877d2bdf68