### PR TITLE
Add math nodes and reverse agent

### DIFF
--- a/backend/app/nodes.py
+++ b/backend/app/nodes.py
@@ -178,3 +178,123 @@ class DelayNode(NodeBase):
         if not isinstance(params.get("ms"), int) or params.get("ms") < 0:
             return ["'ms' must be a non-negative integer"]
         return []
+
+
+@register_node
+class SubtractNode(NodeBase):
+    type = "subtract"
+
+    @classmethod
+    async def execute(
+        cls,
+        node: Dict[str, Any],
+        log: Callable[[str], Awaitable[None]],
+        context: Dict[str, Any],
+    ):
+        params = node.get("params", {})
+        a = params.get("a", 0)
+        b = params.get("b", 0)
+        result = a - b
+        await log(f"{a} - {b} = {result}")
+        context[node.get("id", "result")] = result
+
+    @classmethod
+    def validate(cls, params: Dict[str, Any]) -> List[str]:
+        errors = []
+        if not isinstance(params.get("a"), (int, float)):
+            errors.append("'a' must be a number")
+        if not isinstance(params.get("b"), (int, float)):
+            errors.append("'b' must be a number")
+        return errors
+
+
+@register_node
+class DivideNode(NodeBase):
+    type = "divide"
+
+    @classmethod
+    async def execute(
+        cls,
+        node: Dict[str, Any],
+        log: Callable[[str], Awaitable[None]],
+        context: Dict[str, Any],
+    ):
+        params = node.get("params", {})
+        a = params.get("a", 0)
+        b = params.get("b", 1)
+        if b == 0:
+            await log("division by zero")
+            result = None
+        else:
+            result = a / b
+            await log(f"{a} / {b} = {result}")
+        context[node.get("id", "result")] = result
+
+    @classmethod
+    def validate(cls, params: Dict[str, Any]) -> List[str]:
+        errors = []
+        if not isinstance(params.get("a"), (int, float)):
+            errors.append("'a' must be a number")
+        if not isinstance(params.get("b"), (int, float)):
+            errors.append("'b' must be a number")
+        return errors
+
+
+@register_node
+class PowerNode(NodeBase):
+    type = "power"
+
+    @classmethod
+    async def execute(
+        cls,
+        node: Dict[str, Any],
+        log: Callable[[str], Awaitable[None]],
+        context: Dict[str, Any],
+    ):
+        params = node.get("params", {})
+        a = params.get("a", 0)
+        b = params.get("b", 0)
+        result = a ** b
+        await log(f"{a} ** {b} = {result}")
+        context[node.get("id", "result")] = result
+
+    @classmethod
+    def validate(cls, params: Dict[str, Any]) -> List[str]:
+        errors = []
+        if not isinstance(params.get("a"), (int, float)):
+            errors.append("'a' must be a number")
+        if not isinstance(params.get("b"), (int, float)):
+            errors.append("'b' must be a number")
+        return errors
+
+
+@register_node
+class ModuloNode(NodeBase):
+    type = "modulo"
+
+    @classmethod
+    async def execute(
+        cls,
+        node: Dict[str, Any],
+        log: Callable[[str], Awaitable[None]],
+        context: Dict[str, Any],
+    ):
+        params = node.get("params", {})
+        a = params.get("a", 0)
+        b = params.get("b", 1)
+        if b == 0:
+            await log("modulo by zero")
+            result = None
+        else:
+            result = a % b
+            await log(f"{a} % {b} = {result}")
+        context[node.get("id", "result")] = result
+
+    @classmethod
+    def validate(cls, params: Dict[str, Any]) -> List[str]:
+        errors = []
+        if not isinstance(params.get("a"), (int, float)):
+            errors.append("'a' must be a number")
+        if not isinstance(params.get("b"), (int, float)):
+            errors.append("'b' must be a number")
+        return errors

--- a/backend/app/plugins/reverse_agent.py
+++ b/backend/app/plugins/reverse_agent.py
@@ -1,0 +1,11 @@
+from ..agents import BaseAgent
+
+class ReverseAgent(BaseAgent):
+    """Agent that returns the reversed prompt."""
+
+    async def run(self, prompt: str) -> str:
+        return prompt[::-1]
+
+
+def register():
+    return {"reverse": ReverseAgent()}

--- a/backend/tests/test_agents_api.py
+++ b/backend/tests/test_agents_api.py
@@ -16,6 +16,7 @@ def test_list_agents():
     assert "echo" in agents
     # plugin agent should also be loaded
     assert "uppercase" in agents
+    assert "reverse" in agents
 
 def test_test_agent():
     res = client.post("/agents/echo/test", json={"prompt": "hi"}, headers=HEADERS)
@@ -26,3 +27,8 @@ def test_test_agent():
     res = client.post("/agents/uppercase/test", json={"prompt": "hi"}, headers=HEADERS)
     assert res.status_code == 200
     assert res.json()["response"] == "HI"
+
+    # test reverse plugin agent
+    res = client.post("/agents/reverse/test", json={"prompt": "abc"}, headers=HEADERS)
+    assert res.status_code == 200
+    assert res.json()["response"] == "cba"

--- a/backend/tests/test_nodes.py
+++ b/backend/tests/test_nodes.py
@@ -18,6 +18,10 @@ def test_node_registry():
     assert 'condition' in NODE_REGISTRY
     assert 'loop' in NODE_REGISTRY
     assert 'multiply' in NODE_REGISTRY
+    assert 'subtract' in NODE_REGISTRY
+    assert 'divide' in NODE_REGISTRY
+    assert 'power' in NODE_REGISTRY
+    assert 'modulo' in NODE_REGISTRY
 
 
 def test_workflow_validation_and_execution():
@@ -28,9 +32,13 @@ def test_workflow_validation_and_execution():
             {"id": "1", "type": "print", "params": {"message": "hi"}},
             {"id": "2", "type": "add", "params": {"a": 1, "b": 2}},
             {"id": "3", "type": "multiply", "params": {"a": 3, "b": 4}},
-            {"id": "4", "type": "condition", "params": {"expression": "1 < 2"}},
-            {"id": "5", "type": "loop", "params": {"count": 2}},
-            {"id": "6", "type": "delay", "params": {"ms": 10}}
+            {"id": "4", "type": "subtract", "params": {"a": 5, "b": 3}},
+            {"id": "5", "type": "divide", "params": {"a": 8, "b": 2}},
+            {"id": "6", "type": "power", "params": {"a": 2, "b": 3}},
+            {"id": "7", "type": "modulo", "params": {"a": 7, "b": 4}},
+            {"id": "8", "type": "condition", "params": {"expression": "1 < 2"}},
+            {"id": "9", "type": "loop", "params": {"count": 2}},
+            {"id": "10", "type": "delay", "params": {"ms": 10}}
         ]
     }
     res = client.post("/workflows", json=workflow, headers=HEADERS)
@@ -46,6 +54,10 @@ def test_workflow_validation_and_execution():
     log_text = "\n".join(data["logs"])
     assert "1 + 2 = 3" in log_text
     assert "3 * 4 = 12" in log_text
+    assert "5 - 3 = 2" in log_text
+    assert "8 / 2 = 4.0" in log_text
+    assert "2 ** 3 = 8" in log_text
+    assert "7 % 4 = 3" in log_text
     assert "1 < 2 -> True" in log_text
     assert "loop 1/2" in log_text
 


### PR DESCRIPTION
## Summary
- implement four new math nodes: subtract, divide, power and modulo
- add reverse agent plugin
- test coverage for new nodes and plugin

## Testing
- `pip install -q -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d4fc0aeb0832497cbfc283dba2b4e