### PR TITLE
Fix websocket reconnect and ReactFlow memoization

### DIFF
--- a/frontend/src/LogPanel.jsx
+++ b/frontend/src/LogPanel.jsx
@@ -4,9 +4,24 @@ export default function LogPanel() {
   const [logs, setLogs] = useState([])
 
   useEffect(() => {
-    const ws = new WebSocket('ws://localhost:8000/ws/logs')
-    ws.onmessage = evt => setLogs(l => [...l, evt.data])
-    return () => ws.close()
+    let socket
+    let shouldReconnect = true
+
+    const connect = () => {
+      socket = new WebSocket('ws://localhost:8000/ws/logs')
+      socket.onmessage = evt => setLogs(l => [...l, evt.data])
+      socket.onerror = () => socket.close()
+      socket.onclose = () => {
+        if (shouldReconnect) setTimeout(connect, 1000)
+      }
+    }
+
+    connect()
+
+    return () => {
+      shouldReconnect = false
+      socket?.close()
+    }
   }, [])
 
   return (

--- a/frontend/src/WorkflowCanvas.jsx
+++ b/frontend/src/WorkflowCanvas.jsx
@@ -10,6 +10,7 @@ import NodePalette from './NodePalette.jsx'
 import { nodeConfigs } from './nodeConfigs.js'
 import { useWorkflowStore } from './store.js'
 import LogPanel from './LogPanel.jsx'
+import { nodeTypes, edgeTypes } from './flowTypes.js'
 
 let id = 0
 const getId = () => `node_${id++}`
@@ -17,20 +18,19 @@ const getId = () => `node_${id++}`
 export default function WorkflowCanvas() {
   const reactFlowWrapper = useRef(null)
   const [reactFlowInstance, setReactFlowInstance] = useState(null)
-  const { nodes, edges, setNodes, setEdges, addNode, addEdge } =
-    useWorkflowStore()
+  const { nodes, edges, setNodes, setEdges, addNode } = useWorkflowStore()
 
   const onNodesChange = useCallback(
     changes => setNodes(applyNodeChanges(changes, nodes)),
-    [nodes]
+    [nodes, setNodes]
   )
   const onEdgesChange = useCallback(
     changes => setEdges(applyEdgeChanges(changes, edges)),
-    [edges]
+    [edges, setEdges]
   )
   const onConnect = useCallback(
     params => setEdges(reactAddEdge(params, edges)),
-    [edges]
+    [edges, setEdges]
   )
 
   const onDragOver = useCallback(event => {
@@ -56,7 +56,7 @@ export default function WorkflowCanvas() {
       }
       addNode(newNode)
     },
-    [reactFlowInstance]
+    [reactFlowInstance, addNode]
   )
 
   const handleDragStart = (event, nodeType) => {
@@ -72,6 +72,8 @@ export default function WorkflowCanvas() {
           <ReactFlow
             nodes={nodes}
             edges={edges}
+            nodeTypes={nodeTypes}
+            edgeTypes={edgeTypes}
             onNodesChange={onNodesChange}
             onEdgesChange={onEdgesChange}
             onConnect={onConnect}

--- a/frontend/src/flowTypes.js
+++ b/frontend/src/flowTypes.js
@@ -1,0 +1,2 @@
+export const nodeTypes = {}
+export const edgeTypes = {}


### PR DESCRIPTION
## Summary
- silence React Flow warning by providing memoized `nodeTypes` and `edgeTypes`
- add automatic reconnection logic to the log panel websocket
- pass the memoized types to `ReactFlow`
- keep ESLint happy

## Testing
- `npm run lint`
- `npm run build`
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686d65cc9dc083249d5e949a454c6839