### PR TITLE
Install websocket dependencies

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,5 +1,5 @@
 fastapi
-uvicorn
+uvicorn[standard]
 pydantic
 pytest
 httpx


### PR DESCRIPTION
## Summary
- add websocket support by switching to `uvicorn[standard]`

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686d78cc1c888324a7d2aecdb55a25b7