### PR TITLE
Bug fix: enable node drop

### DIFF
--- a/frontend/src/WorkflowCanvas.jsx
+++ b/frontend/src/WorkflowCanvas.jsx
@@ -62,6 +62,8 @@ export default function WorkflowCanvas() {
 
   const handleDragStart = (event, nodeType) => {
     event.dataTransfer.setData('application/reactflow', nodeType)
+    // some browsers require a text/plain data entry for drag events
+    event.dataTransfer.setData('text/plain', nodeType)
     event.dataTransfer.effectAllowed = 'move'
   }
 


### PR DESCRIPTION
## Summary
- fix dropping nodes on the workflow canvas by adding a `text/plain` dataTransfer entry

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d7e45c8d483249a2371d3da407336